### PR TITLE
Storing and reading events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ erl_crash.dump
 
 # Files matching the following pattern may contain sensitive data.
 **/config/*.secret.exs
+
+# We don't want to include Mnesia DB
+**/Mnesia*/

--- a/apps/api/lib/api_web/controllers/events_controller.ex
+++ b/apps/api/lib/api_web/controllers/events_controller.ex
@@ -1,0 +1,30 @@
+defmodule ApiWeb.EventsController do
+  @moduledoc """
+  Web interface for viewing events
+  """
+
+  use ApiWeb, :controller
+
+  alias Core.EventRepo
+
+  action_fallback(ApiWeb.ErrorsController)
+
+  def index(conn, _opts) do
+    {:ok, events} = EventRepo.events()
+    json(conn, %{data: %{events: events}})
+  end
+
+  def show(conn, %{"id" => raw_id}) do
+    with {:ok, id} <- Helpers.Integer.parse(raw_id),
+         {:ok, events} <- EventRepo.get_event(id) do
+      json(conn, %{data: %{events: events}})
+    end
+  end
+
+  def show(conn, %{"operation" => operation}) do
+    with operation <- String.to_existing_atom(operation),
+         {:ok, events} <- EventRepo.get_event(operation) do
+      json(conn, %{data: %{events: events}})
+    end
+  end
+end

--- a/apps/api/lib/api_web/router.ex
+++ b/apps/api/lib/api_web/router.ex
@@ -10,5 +10,8 @@ defmodule ApiWeb.Router do
 
     resources "/users", UsersController, only: [:index, :show, :create, :update, :delete]
     resources "/posts", PostsController, only: [:index, :create]
+    get "/events", EventsController, :index
+    get "/events/:id", EventsController, :show
+    get "/events/operation/:operation", EventsController, :show
   end
 end

--- a/apps/core/lib/core/application.ex
+++ b/apps/core/lib/core/application.ex
@@ -4,8 +4,15 @@ defmodule Core.Application do
   use Application
 
   def start(_type, _args) do
+    configure_mnesia()
     children = [Core.Repo]
     opts = [strategy: :one_for_one, name: Core.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp configure_mnesia() do
+    :mnesia.create_schema([node()])
+    Application.ensure_started(:mnesia)
+    :mnesia.create_table(Event, [attributes: [:id, :user_id, :operation, :values, :time], disc_copies: [node()], type: :ordered_set])
   end
 end

--- a/apps/core/lib/core/event_repo.ex
+++ b/apps/core/lib/core/event_repo.ex
@@ -1,0 +1,62 @@
+defmodule Core.EventRepo do
+  @type operation ::
+          :user_created
+          | :user_updated
+          | :user_deleted
+          | :post_created
+
+@spec save_event(operation, {pos_integer(), String.t(), any()}) :: :ok | {:error, any()}
+  def save_event(:user_created, {user_id, user_email, time}),
+    do: write_to_mnesia(user_id, :user_created, %{user_email: user_email}, time)
+
+  def save_event(:user_updated, {user_id, attrs, time}),
+    do: write_to_mnesia(user_id, :user_updated, attrs, time)
+
+  def save_event(:user_deleted, {user_id, time}),
+    do: write_to_mnesia(user_id, :user_deleted, %{}, time)
+
+  def save_event(:post_created, {user_id, post_id, post_body, time}),
+    do:
+      write_to_mnesia(
+        user_id,
+        :post_created,
+        %{user_id: user_id, post_id: post_id, post_body: post_body},
+        time
+      )
+
+  def save_event(_, _), do: {:error, :invalid_operation}
+
+  defp write_to_mnesia(user_id, operation, attrs, time) do
+    case :mnesia.transaction(fn ->
+           :mnesia.write({Event, get_next_index(), user_id, operation, attrs, time})
+         end) do
+      {:atomic, :ok} -> :ok
+      {:aborted, reason} -> {:error, reason}
+    end
+  end
+
+  @spec get_event(pos_integer() | operation) :: {:ok, [list(keyword())]} | {:error, any()}
+  def get_event(user_id) when is_integer(user_id), do: read_from_mnesia(user_id, :_)
+  def get_event(operation) when is_atom(operation), do: read_from_mnesia(:_, operation)
+  def get_event(_), do: events()
+  def events, do: read_from_mnesia(:_, :_)
+
+  defp read_from_mnesia(user_id, operation) do
+    case :mnesia.transaction(fn ->
+           :mnesia.match_object({Event, :_, user_id, operation, :_, :_})
+         end) do
+      {:atomic, result} -> {:ok, Enum.map(result, &parse/1)}
+      {:aborted, reason} -> {:error, reason}
+    end
+  end
+
+  defp get_next_index() do
+    case :mnesia.transaction(fn -> :mnesia.last(Event) end) do
+      {:atomic, :"$end_of_table"} -> 1
+      {:atomic, num} -> num + 1
+    end
+  end
+
+  defp parse({_, event_id, user_id, operation, attrs, time}),
+    do: %{event_id: event_id, user_id: user_id, operation: operation, attrs: attrs, time: time}
+end

--- a/apps/core/lib/core/feed.ex
+++ b/apps/core/lib/core/feed.ex
@@ -6,6 +6,7 @@ defmodule Core.Feed do
   alias Core.Accounts.User
   alias Core.Feed.Post
   alias Core.Repo
+  alias Core.EventRepo
 
   import Ecto.Query
 
@@ -20,8 +21,10 @@ defmodule Core.Feed do
 
   @spec create_post(attrs :: map()) :: Repo.modify_result_t(Post.t())
   def create_post(%{} = attrs) do
-    with {:ok, post} <- Post.create_changeset(attrs) |> Repo.insert() do
-      {:ok, Repo.preload(post, :user)}
-    end
+    with {:ok, post} <- Post.create_changeset(attrs) |> Repo.insert(), 
+      post <- Repo.preload(post, :user),
+      :ok <- EventRepo.save_event(:post_created, {post.user_id, post.id, post.text, post.inserted_at}) do
+        {:ok, post}
+      end
   end
 end


### PR DESCRIPTION
Added Mnesia-based storage for events regarding creare/update/delete for
user and creation of posts. All needed info is stored on disk.
API was exposed to read all events or by user_id/operation.

This closes #3 

I had no time/idea how to properly implement tests for this, sadly.